### PR TITLE
Reduce cron frequency to daily + shift to off-peak

### DIFF
--- a/.github/workflows/update-wow-version.yml
+++ b/.github/workflows/update-wow-version.yml
@@ -2,7 +2,7 @@ name: Auto-update WoW interface version
 
 on:
   schedule:
-    - cron: '*/5 * * * *'  # Every 5 minutes — minimum GitHub interval, public repo so free
+    - cron: '7 4 * * *'  # Daily at 04:07 UTC (prime minute, off-peak). Manual `workflow_dispatch` on patch day catches new versions immediately.
   workflow_dispatch:         # Allow manual trigger from the Actions tab
 
 concurrency:


### PR DESCRIPTION
Reduce `update-wow-version.yml` cron from every-5-min to daily, and move off the GitHub-documented peak `:00`/`:05`/`:10`/... slots.

## Shift

| File / Line | Old | New | Why |
|---|---|---|---|
| `.github/workflows/update-wow-version.yml:5` | `*/5 * * * *` (288 fires/day) | `7 4 * * *` (1 fire/day) | Per ≤1/24h policy. `*/5` fires on every 5-min multiple — all peak slots — and 288/day on a public free-tier repo is high burn. :07 prime, hour 04 in preferred 04-10 UTC window. |

## Trade-off, eyes-open

The previous cadence detected new WoW patches within ~5 min so the addon's `## Interface:` line could be auto-bumped before users hit "interface out of date" warnings on next login. The new cadence means:

- Up to **~24h lag** between Blizzard shipping a patch and the .toc Interface bump.
- During that lag window, users who log in will see "this addon is out of date" until they manually disable the version check.

**Mitigation:** On patch day, manually trigger via Actions → Auto-update WoW interface version → Run workflow. The `workflow_dispatch` trigger remains in place; it catches new patches immediately.

If the post-patch user-experience hit turns out to be worse than expected, revisit and consider:
- Patch-day-only hourly cadence (e.g. hourly Tue 17:00-23:00 UTC, daily otherwise).
- A push-based trigger from an external watchdog instead of polling.

## Not changed
- Workflow logic (Blizzard NGDP poll → parse → .toc edit → commit).
- `concurrency` block.
- `workflow_dispatch` trigger.

## Test plan
- [ ] Actions tab shows new schedule (`7 4 * * *`) after merge.
- [ ] First scheduled fire lands at 04:07 UTC.
- [ ] On next WoW patch ship: confirm manual `workflow_dispatch` catches it.